### PR TITLE
chore: Create dist folder

### DIFF
--- a/.changeset/khaki-kangaroos-stare.md
+++ b/.changeset/khaki-kangaroos-stare.md
@@ -1,0 +1,5 @@
+---
+"@flemmingbehrend/x-correlation-id": minor
+---
+
+added dist folder to published package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ jobs:
 
       - name: install dependencies
         run: pnpm install
+
+      - name: create dist folder
+        run: pnpm build
         
       - name: create and publish versions
         uses: changesets/action@v1

--- a/packages/x-correlation-id/CHANGELOG.md
+++ b/packages/x-correlation-id/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - 335c69f: fix publish
 
-## 1.0.1
+## 0.0.1
 
 ### Patch Changes
 


### PR DESCRIPTION
Add build to release workflow to generate the dist folder.

It was missing from the published package.